### PR TITLE
README Installation & Usage steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,13 @@ Note that you do not include the `openapi.json` extension within the URL.
 
 
 SDKs will be generated in the [clients directory](clients)
+
+## Examples
+    
+To verify that the SDKs are working, you can follow those examples:
+
+* [Python client](./clients/python/README.md)
+* [JavaScript client](./clients/javascript/README.md)
+* [Golang client](./clients/golang/README.md)
+
+(For more examples, see the [clients directory](./clients/))

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ git clone https://github.com/gladiaio/gladia-sdk.git ; cd gladia-sdk
 
 ## Usage
 
-You first need to start the [Gladia's API](https://github.com/gladiaio/gladia) by following [it README](https://github.com/gladiaio/gladia#magic-start).
+You first need to start the [Gladia's API](https://github.com/gladiaio/gladia) by following [its README](https://github.com/gladiaio/gladia#magic-start).
 
 We recommend to first clean the  [clients directory](clients) to prevent any deprecated SDK:
 ```sh

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We recommend to first clean the  [clients directory](clients) to prevent any dep
 rm -rf clients/*
 ```
 
-Then provide the gladia API URL (by default it's `http://localhost:8080`) to the following command:
+Then set `GLADIA_API_URL` in your environment as the URL of the Gladia's API (by default it's `http://localhost:8080`) and provide it to the following command:
 ```sh
 cd generator ; python generate_sdk.py $GLADIA_API_URL
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# unifai-sdk
+# Gladia's SDKs
+
+Automatic SDK generation from Gladia's OpenAPI definition.
+
+## Installation
+
+```sh
+git clone https://github.com/gladiaio/gladia-sdk.git ; cd gladia-sdk
+```
+
+## Usage
+
+You first need to start the [Gladia's API](https://github.com/gladiaio/gladia) by following [it README](https://github.com/gladiaio/gladia#magic-start).
+
+We recommend to first clean the  [clients directory](clients) to prevent any deprecated SDK:
+```sh
+rm -rf clients/*
+```
+
+Then provide the gladia API URL (by default it's `http://localhost:8080`) to the following command:
+```sh
+cd generator ; python generate_sdk.py $GLADIA_API_URL
+```
+Note that you do not include the `openapi.json` extension within the URL.
+
+
+SDKs will be generated in the [clients directory](clients)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Automatic SDK generation from Gladia's OpenAPI definition.
 
+## Requirements
+
+Before running this script, you need to have the following dependencies:
+* Python 3.6+
+    * `easyargs==0.9.*`
+* Docker 20.03+
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
The README now has :
* An `Installation` step describing how to install the repository.
* An `Usage` step describing how to generate the SDKs